### PR TITLE
Reporting tools 

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,15 +1,10 @@
-name: CI
+name: Report
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
-  workflow_dispatch:
 
 jobs:
-  build:
+  report:
     runs-on: ubuntu-latest
     container: aiplan4eu/unified-planning
 
@@ -29,14 +24,11 @@ jobs:
       - name: Install Unified-Planning
         run: python3 -m pip install unified-planning/
 
-      - name: Checkout Pyperplan Unified-Planning interface
-        uses: actions/checkout@v2
-        with:
-          repository: aiplan4eu/up-pyperplan
-          path: up-pyperplan
+      - name: Install tamer
+        run: python3 -m pip install up-tamer --pre
 
-      - name: Install Pyperplan Unified-Planning interface
-        run: python3 -m pip install up-pyperplan/
+      - name: Install Aries (dev-build)
+        run: python3 -m pip install https://github.com/plaans/aries/releases/download/latest/up_aries.tar.gz
 
-      - name: Run tests
-        run: python3 runner.py
+      - name: Report
+        run: 'python3 report.py --prefix up: ; true'

--- a/planning_tests/commons/problem.py
+++ b/planning_tests/commons/problem.py
@@ -1,3 +1,6 @@
+from fractions import Fraction
+from typing import Optional, Union
+
 import unified_planning
 
 class TestCaseProblem(object):
@@ -17,9 +20,10 @@ class TestCaseProblem(object):
     
 
 class TestCase:
-    def __init__(self, problem: unified_planning.model.Problem, solvable: bool):
+    def __init__(self, problem: unified_planning.model.Problem, solvable: bool, optimum: Optional[Union[int, Fraction]] = None):
         self._problem = problem
         self._solvable = solvable
+        self._optimum = optimum
 
     @property
     def problem(self) -> unified_planning.model.Problem:
@@ -32,6 +36,10 @@ class TestCase:
     @property
     def name(self) -> str:
         return self.problem.name
+
+    @property
+    def optimum(self) -> Optional[Union[int, Fraction]]:
+        return self._optimum
 
 
 class PDDLTestCase(TestCase):

--- a/planning_tests/commons/problem.py
+++ b/planning_tests/commons/problem.py
@@ -1,3 +1,4 @@
+import unified_planning
 
 class TestCaseProblem(object):
     def __init__(self, expected_version):
@@ -13,3 +14,43 @@ class TestCaseProblem(object):
 
     def version(self):
         raise NotImplementedError
+    
+
+class TestCase:
+    def __init__(self, problem: unified_planning.model.Problem, solvable: bool):
+        self._problem = problem
+        self._solvable = solvable
+
+    def problem(self) -> unified_planning.model.Problem:
+        return self._problem
+
+    @property
+    def solvable(self) -> bool:
+        return self._solvable
+
+    @property
+    def name(self) -> str:
+        return self.problem().name
+
+
+class PDDLTestCase(TestCase):
+    """A specialization of `TestCase` for file-based PDDL problems.
+       The PDDL problems will be lazily parsed on the first access and the problem cached.
+    """
+    def __init__(self, name: str, domain: str, problem: str, solvable: bool):
+        self._name = name
+        self._domain_file = domain
+        self._problem_file = problem
+        super().__init__(problem=None, solvable=solvable)
+
+    def problem(self):
+        if self._problem is None:
+            # problem has not been parsed yet, parse and store
+            from unified_planning.io import PDDLReader
+            self._problem = PDDLReader().parse_problem(self._domain_file, self._problem_file)
+            self._problem.name = self._name
+        return self._problem
+
+    @property
+    def name(self):
+        return self._name # return the name passed to the constructor (avoids parsing the file)

--- a/planning_tests/commons/problem.py
+++ b/planning_tests/commons/problem.py
@@ -21,6 +21,7 @@ class TestCase:
         self._problem = problem
         self._solvable = solvable
 
+    @property
     def problem(self) -> unified_planning.model.Problem:
         return self._problem
 
@@ -30,7 +31,7 @@ class TestCase:
 
     @property
     def name(self) -> str:
-        return self.problem().name
+        return self.problem.name
 
 
 class PDDLTestCase(TestCase):
@@ -43,6 +44,7 @@ class PDDLTestCase(TestCase):
         self._problem_file = problem
         super().__init__(problem=None, solvable=solvable)
 
+    @property
     def problem(self):
         if self._problem is None:
             # problem has not been parsed yet, parse and store

--- a/planning_tests/commons/results.py
+++ b/planning_tests/commons/results.py
@@ -1,0 +1,77 @@
+from typing import List
+
+
+class bcolors:
+    """Just a holder for terminal colors"""
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARN = '\033[93m'
+    ERR = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+class ResultSet:
+    def ok(self) -> bool:
+        pass
+
+    def __add__(self, other: 'ResultSet') -> 'ResultSet':
+        return ResultList([self, other])
+
+
+class Void(ResultSet):
+    def ok(self):
+        return True
+
+    def __str__(self):
+        return ""
+
+
+class Ok(ResultSet):
+    def __init__(self, msg: str = ""):
+        self.msg = msg
+
+    def ok(self) -> bool:
+        return True
+
+    def __str__(self):
+        if self.msg == "":
+            return ""
+        else:
+            return f"{bcolors.OKGREEN}OK({self.msg}){bcolors.ENDC} "
+
+
+class Warn(ResultSet):
+    def __init__(self, msg: str = ""):
+        self.msg = msg
+
+    def ok(self) -> bool:
+        return True
+
+    def __str__(self):
+        return f"{bcolors.WARN}WARN({self.msg}){bcolors.ENDC} "
+
+
+class Err(ResultSet):
+    def __init__(self, msg: str = ""):
+        self.msg = msg
+
+    def ok(self) -> bool:
+        return False
+
+    def __str__(self):
+        return f"{bcolors.ERR}Err({self.msg}){bcolors.ENDC} "
+
+
+class ResultList(ResultSet):
+    def __init__(self, results: List[ResultSet]):
+        self.results = results
+
+    def ok(self) -> bool:
+        return all(r.ok() for r in self.results)
+
+    def __str__(self):
+        return "".join(map(str, self.results))

--- a/planning_tests/refinement_planning/__init__.py
+++ b/planning_tests/refinement_planning/__init__.py
@@ -1,0 +1,5 @@
+from planning_tests.refinement_planning import hddl, optimal
+
+
+def problems():
+    return optimal.problems() + hddl.problems()

--- a/planning_tests/refinement_planning/hddl/README.md
+++ b/planning_tests/refinement_planning/hddl/README.md
@@ -1,0 +1,13 @@
+This provides access to 28 domains from the 2020 IPC for hierarchical planning.
+
+The domains are distributed with `unified_planning` library in the set of tests. 
+This module simply exposes a more convenient interface for them.
+They can be retrieved problems can be retrieved with `planning_tests.refinement_planning.hddl.problems()`.
+
+
+
+
+Omitted domains from IPC 2020:
+ - 2020-po-UM-Translog: requires multiple inheritance for types.
+ - 2020-po-Woodworking: has conflicting effects in at least somes actions
+ - 2020-po-Barman-BDI, 2020-po-Barman-BDI, 2020-to-Freecell-Learned-ECAI-16: duplicated names in the domain

--- a/planning_tests/refinement_planning/hddl/__init__.py
+++ b/planning_tests/refinement_planning/hddl/__init__.py
@@ -1,0 +1,44 @@
+
+import os
+from typing import List
+
+import unified_planning.test
+from planning_tests.commons.problem import PDDLTestCase
+
+# cache of a set of prebuilt HDDL problems
+# This is important to avoid parsing the HDDL problems multiple times.
+_HDDL_PROBLEMS = None
+
+
+def problems() -> List[PDDLTestCase]:
+    """Returns a list of PDDL test cases."""
+    global _HDDL_PROBLEMS
+    if _HDDL_PROBLEMS is None:
+        # HDDL problems were not discovered yet,
+        # look for them in the unified_planning distribution `unified_planning/test/hddl`
+        up_tests_path = os.path.dirname(unified_planning.test.__file__)
+        # directory where to find hddl instances
+        hddl_dir = os.path.join(up_tests_path, "hddl")
+
+        subfolders = [f.path for f in os.scandir(hddl_dir) if f.is_dir()]
+        problems = []
+        for id, domain in enumerate(subfolders[:]):
+            domain_filename = os.path.join(domain, "domain.hddl")
+            problem_filename = os.path.join(domain, "instance.1.pb.hddl")
+
+            if os.path.exists(domain_filename):
+                problem_name = "hddl:" + os.path.basename(domain)
+                # Adds a PDDL test case for this file.
+                problems.append(PDDLTestCase(
+                    name=problem_name,
+                    domain=domain_filename,
+                    problem=problem_filename,
+                    solvable=True
+                ))
+        _HDDL_PROBLEMS = problems
+
+    return _HDDL_PROBLEMS
+
+
+
+            

--- a/planning_tests/refinement_planning/optimal.py
+++ b/planning_tests/refinement_planning/optimal.py
@@ -1,0 +1,77 @@
+from unified_planning.shortcuts import *
+from unified_planning.model.htn import *
+
+from planning_tests.commons.problem import TestCase
+
+Location = UserType("Location")
+objects = [
+    Object(f"l{i}", Location) for i in range(5)
+]
+t1 = Task("t1")
+t2 = Task("t2")
+t3 = Task("t3")
+
+actions = [InstantaneousAction(f"a{i}") for i in range(10)]
+
+
+def base():
+    pb = HierarchicalProblem()
+    pb.add_objects(objects)
+    for action in actions:
+        pb.add_action(action)
+    for task in [t1, t2, t3]:
+        pb.add_task(task)
+    pb.task_network.add_subtask(t1)
+    return pb
+
+
+def add_method(pb, name, task, *subtasks):
+    m = Method(name)
+    m.set_task(task)
+    subtasks = [m.add_subtask(st) for st in subtasks]
+    m.set_ordered(*subtasks)
+    pb.add_method(m)
+
+
+def set_costs(pb, *costs):
+    cost_map = {}
+    for action, cost in zip(actions, costs):
+        cost_map[action] = Int(cost)
+    pb.add_quality_metric(up.model.metrics.MinimizeActionCosts(cost_map))
+
+
+def problems():
+    """Generates deterministically a set of non-recursive HTN problems with known optimum."""
+    pbs = []
+
+    def export(pb, optimum, *costs):
+        clone = pb.clone()
+        set_costs(clone, *costs)
+        clone.name = f"htn:opti-action-costs-{len(pbs)}"
+        test_case = TestCase(clone, solvable=True, optimum=optimum)
+        pbs.append(test_case)
+
+    pb = base()
+    add_method(pb, "m11", t1, actions[0], actions[1])
+    add_method(pb, "m12", t1, actions[2])
+
+    export(pb, 3, 2, 2, 3)
+    export(pb, 4, 2, 2, 4)
+    export(pb, 4, 2, 2, 5)
+
+    pb = base()
+    add_method(pb, "m11", t1, t2, t3)
+    add_method(pb, "m21", t2, actions[0], actions[1])
+    add_method(pb, "m31", t3, actions[2], actions[3])
+    add_method(pb, "m32", t3, actions[4], actions[5], actions[6])
+    export(pb, 4,    1, 1,   1, 1,   1, 1, 1)
+    export(pb, 3,    1, 1,   1, 1,   0, 0, 1)
+    export(pb, 5,    1, 1,   1, 10,   1, 1, 1)
+    export(pb, 13,   1, 1,   1, 10,   1, 10, 1)
+    export(pb, 202,   1, 1,   100, 100,   100, 100, 100)
+    return pbs
+
+
+if __name__ == "__main__":
+    for problem, cost in problems():
+        print(problem)

--- a/report.py
+++ b/report.py
@@ -1,29 +1,27 @@
 import os
+import sys
 import time
 
-from unified_planning.engines import PlanGenerationResultStatus
-
-
-
-
-# pip install https://github.com/plaans/aries/releases/download/latest/up_aries.tar.gz
+from unified_planning.engines import PlanGenerationResultStatus, ValidationResultStatus, PlanGenerationResult
+from unified_planning.plans import Plan
 
 from unified_planning.shortcuts import *
-from unified_planning.model.htn import *
-import unified_planning as up
 from unified_planning.environment import get_environment
 
 import planning_tests.refinement_planning.hddl
 from planning_tests.commons.problem import TestCase
+from planning_tests.commons.results import *
 
-get_environment().factory.add_engine('aries', 'up_aries', 'AriesDev')
-#get_environment().factory.add_engine('aries', 'up_aries', 'Aries')
-get_environment().credits_stream = None # silence credits
+get_environment().credits_stream = None  # silence credits
+
+
+def all_test_cases():
+    """Returns all test cases of this repository"""
+    return up_tests() + planning_tests.refinement_planning.hddl.problems()
 
 
 def oneshot_planners():
     """All available oneshot planners."""
-    # return ["aries"]
     tags = [n for n in get_environment().factory.engines]
     tags = [t for t in tags
             if get_environment().factory.engine(t).is_oneshot_planner()]
@@ -31,7 +29,7 @@ def oneshot_planners():
 
 
 def up_tests():
-    """"All test cases defined in the `unified_planning` module. All are assumed to be solvable."""
+    """All test cases defined in the `unified_planning.test` module. All are assumed to be solvable."""
     from unified_planning.test.examples import get_example_problems
 
     cases = []
@@ -42,46 +40,127 @@ def up_tests():
     return cases
 
 
-def run(planners: List[str], problems: List[TestCase]):
+def validate_plan(plan: Plan, problem: Problem) -> ResultSet:
+    try:
+        with PlanValidator(problem_kind=problem.kind) as validator:
+            if not validator.supports_plan(plan.kind):
+                return Warn(f"Validator {validator.name} does not support plan")
+            check = validator.validate(problem, plan)
+            if check.status is ValidationResultStatus.VALID:
+                return Ok("Valid")
+            else:
+                return Err("INVALID")
+    except unified_planning.exceptions.UPNoSuitableEngineAvailableException:
+        return Warn("No validator for problem")
+    except Exception as e:
+        return Warn(f"Validator crash ({e})")
+
+
+def verify(cond: bool, error_tag: str, ok_tag: str = "") -> ResultSet:
+    """Returns an Error if the condition passed in parameter does not hold."""
+    if cond:
+        return Ok(ok_tag)
+    else:
+        return Err(error_tag)
+
+
+def check_result(test: TestCase, result: PlanGenerationResult, planner) -> ResultSet:
+    output = Void()
+    output += verify(result.status != PlanGenerationResultStatus.INTERNAL_ERROR, "forbidden internal error")
+
+    if result.plan:
+        if not test.solvable:
+            output += Err("Unsolvable problem")
+        # if the planner guarantees optimality, this should be reflected in
+        # the result status
+        metrics = test.problem.quality_metrics
+        if not metrics:
+            output += verify(result.status is PlanGenerationResultStatus.SOLVED_SATISFICING, "expected SAT ")
+        else:
+            if planner.satisfies(OptimalityGuarantee.SOLVED_OPTIMALLY):
+                output += verify(result.status is PlanGenerationResultStatus.SOLVED_OPTIMALLY, "expected OPT")
+            else:
+                output += verify(result.status in (PlanGenerationResultStatus.SOLVED_OPTIMALLY,
+                                         PlanGenerationResultStatus.SOLVED_SATISFICING), "expected SAT/OPT")
+        output += validate_plan(result.plan, test.problem)
+    elif test.solvable:
+        output += verify(result.status != PlanGenerationResultStatus.UNSOLVABLE_PROVEN, "UNSOLVABLE on solvable problem")
+        # We are only running the test on solvable instances
+        output += verify(result.status in (PlanGenerationResultStatus.TIMEOUT,
+                                           PlanGenerationResultStatus.MEMOUT,
+                                           PlanGenerationResultStatus.UNSUPPORTED_PROBLEM,
+                                           PlanGenerationResultStatus.UNSOLVABLE_INCOMPLETELY), "invalid status")
+        output += Warn(f"Unsolved ({result.status.name})")
+    else:
+        output += verify(result.status in (PlanGenerationResultStatus.UNSOLVABLE_PROVEN,
+                                           PlanGenerationResultStatus.TIMEOUT,
+                                           PlanGenerationResultStatus.MEMOUT,
+                                           PlanGenerationResultStatus.UNSUPPORTED_PROBLEM,
+                                           PlanGenerationResultStatus.UNSOLVABLE_INCOMPLETELY), "invalid status")
+
+    return output
+
+
+def run(planners: List[str], problems: List[TestCase], timeout=1) -> List[Tuple[str, str]]:
+    errors = []
     for test_case in problems:
         print()
         print(test_case.name.ljust(40), end='\n')
-        pb = test_case.problem()
+        pb = test_case.problem
 
         for planner_id in planners:
             planner = OneshotPlanner(name=planner_id)
             if planner.supports(pb.kind):
 
-                print("  ", planner_id.ljust(80), end='')
+                print("|  ", planner_id.ljust(40), end='')
                 start = time.time()
                 try:
-                    result = planner.solve(pb, timeout=1) #, output_stream=sys.stdout)
+                    result = planner.solve(pb, timeout=timeout)
                     end = time.time()
-                    status = str(result.status).replace("PlanGenerationResultStatus.", "").ljust(20)
-                    print("\t  ", status, "\t    ", end - start)
-                    if result.status == PlanGenerationResultStatus.INTERNAL_ERROR and result.log_messages is not None:
-                        print('\n'.join(map(str, result.log_messages)))
+                    status = str(result.status.name).ljust(25)
+                    outcome = check_result(test_case, result, planner)
+                    if not outcome.ok():
+                        errors.append((planner_id, test_case.name))
+                    runtime = "{:.3f}s".format(end - start).ljust(10)
+                    print(status, "    ", runtime, outcome)
 
                 except Exception as e:
-                    print("\t CRASH !!!!", e)
+                    print(f"{bcolors.ERR}CRASH{bcolors.ENDC}", e)
+                    errors.append((planner_id, test_case.name))
+    return errors
 
 
-def report(*planners: str,
-           problem_prefix: str = ""):
+def report(*planners: str, problem_prefix: str = ""):
+    """Run all planners on all problems that start with the given prefix"""
 
     if len(planners) == 0:
         planners = oneshot_planners()
 
-    problems = up_tests() + planning_tests.refinement_planning.hddl.problems()
+    problems = all_test_cases()
     problems = [p for p in problems if p.name.startswith(problem_prefix)]
-    run(planners, problems)
+    errors = run(planners, problems)
+    if len(errors) > 0:
+        print("Errors:\n ", "\n  ".join(map(str, errors)))
+    return errors
 
 
 if __name__ == "__main__":
-    # report(planner="fast-downward", problem_prefix="up:")
-    report("aries", "fast-downward",
-           problem_prefix="up:basic")
-    report("aries")
+    print("""Validate the results of solvers on a set of planning problems.
+Usage
+ - python report.py                          # will run all solvers on all all problems
+ - python report.py aries tamer              # will run aries an tamer on all problems they support 
+ - python report.py aries --prefix up:basic  # will run aries on all problems whose name starts with "up:basic" """)
+    planners = sys.argv[1:]
+    try:
+        prefix_opt = planners.index("--prefix")
+        planners.pop(prefix_opt)
+        prefix = planners.pop(prefix_opt)
+    except ValueError:
+        prefix = ""
+    print(prefix_opt)
 
-    report()
+    errors = report(*planners, problem_prefix=prefix)
+    if len(errors) > 0:
+        sys.exit(1)
+
 

--- a/report.py
+++ b/report.py
@@ -17,7 +17,7 @@ get_environment().credits_stream = None  # silence credits
 
 def all_test_cases():
     """Returns all test cases of this repository"""
-    return up_tests() + planning_tests.refinement_planning.hddl.problems()
+    return up_tests() + planning_tests.refinement_planning.problems()
 
 
 def oneshot_planners():

--- a/report.py
+++ b/report.py
@@ -12,10 +12,17 @@ from unified_planning.shortcuts import *
 from unified_planning.model.htn import *
 import unified_planning as up
 from unified_planning.environment import get_environment
+
+import planning_tests.refinement_planning.hddl
+from planning_tests.commons.problem import TestCase
+
 get_environment().factory.add_engine('aries', 'up_aries', 'AriesDev')
+#get_environment().factory.add_engine('aries', 'up_aries', 'Aries')
 get_environment().credits_stream = None # silence credits
 
+
 def oneshot_planners():
+    """All available oneshot planners."""
     # return ["aries"]
     tags = [n for n in get_environment().factory.engines]
     tags = [t for t in tags
@@ -24,6 +31,7 @@ def oneshot_planners():
 
 
 def up_tests():
+    """"All test cases defined in the `unified_planning` module. All are assumed to be solvable."""
     from unified_planning.test.examples import get_example_problems
 
     cases = []
@@ -34,91 +42,17 @@ def up_tests():
     return cases
 
 
-def hddl_problems():
-    import os
-    import unified_planning.test
-    up_tests_path = os.path.dirname(unified_planning.test.__file__)
-    # directory where to find hddl instances
-    hddl_dir = os.path.join(up_tests_path, "hddl")
-
-    subfolders = [f.path for f in os.scandir(hddl_dir) if f.is_dir()]
-    problems = []
-    for id, domain in enumerate(subfolders[:]):
-        domain_filename = os.path.join(domain, "domain.hddl")
-        problem_filename = os.path.join(domain, "instance.1.pb.hddl")
-
-        if os.path.exists(domain_filename):
-            problem_name = "hddl:" + os.path.basename(domain)
-            problems.append(PDDLTestCase(
-                name=problem_name,
-                domain=domain_filename,
-                problem=problem_filename,
-                solvable=True
-            ))
-
-    return problems
-
-
-class TestCase:
-    def __init__(self, problem: up.model.Problem, solvable: bool):
-        self._problem = problem
-        self._solvable = solvable
-
-    def problem(self) -> up.model.Problem:
-        return self._problem
-
-    @property
-    def solvable(self):
-        return self._solvable
-
-    @property
-    def name(self) -> str:
-        return self.problem().name
-
-class PDDLTestCase(TestCase):
-    def __init__(self, name: str, domain: str, problem: str, solvable: bool):
-        self._name = name
-        self._domain_file = domain
-        self._problem_file = problem
-        super().__init__(problem=None, solvable=solvable)
-
-    def problem(self):
-        if self._problem is None:
-            # problem has not been parsed yet, parse and store
-            from unified_planning.io import PDDLReader
-            self._problem = PDDLReader().parse_problem(self._domain_file, self._problem_file)
-            self._problem.name = self._name
-        return self._problem
-
-    @property
-    def name(self):
-        return self._name
-
-
-def report(planner: Optional[str] = None,
-           planners: Optional[List[str]] = None,
-           problem_prefix: str = ""):
-
-    if planner is not None:
-        planners = [planner]
-    if planners is None:
-        planners = oneshot_planners()
-
-    problems = up_tests() + hddl_problems()
-    problems = [p for p in problems if p.name.startswith(problem_prefix)]
-
+def run(planners: List[str], problems: List[TestCase]):
     for test_case in problems:
-        # if test_case.name != "up:htn-go-temporal":
-        #     continue
         print()
         print(test_case.name.ljust(40), end='\n')
         pb = test_case.problem()
 
-        for planner in planners:
-            planner = OneshotPlanner(name=planner)
+        for planner_id in planners:
+            planner = OneshotPlanner(name=planner_id)
             if planner.supports(pb.kind):
 
-                print("  ", planner.name.ljust(80), end='')
+                print("  ", planner_id.ljust(80), end='')
                 start = time.time()
                 try:
                     result = planner.solve(pb, timeout=1) #, output_stream=sys.stdout)
@@ -131,50 +65,23 @@ def report(planner: Optional[str] = None,
                 except Exception as e:
                     print("\t CRASH !!!!", e)
 
-    
 
-TEST_REPO_DIR = os.path.dirname(os.path.realpath(__file__))
+def report(*planners: str,
+           problem_prefix: str = ""):
+
+    if len(planners) == 0:
+        planners = oneshot_planners()
+
+    problems = up_tests() + planning_tests.refinement_planning.hddl.problems()
+    problems = [p for p in problems if p.name.startswith(problem_prefix)]
+    run(planners, problems)
 
 
 if __name__ == "__main__":
-
     # report(planner="fast-downward", problem_prefix="up:")
-    report(planners=["aries","fast-downward"], problem_prefix="hddl")
+    report("aries", "fast-downward",
+           problem_prefix="up:basic")
+    report("aries")
 
-    # # aries = up_aries.Aries()
-    # planners = oneshot_planners()
-    # print(planners)
-    #
-    # pbs = []
-    # pbs += up_tests()
-    # pbs += hddl_problems()
-    #
-    # planner = OneshotPlanner(name="aries")
-    #
-    #
-    # for test_case in pbs:
-    #     # if test_case.name != "up:htn-go-temporal":
-    #     #     continue
-    #     print()
-    #     print(test_case.name.ljust(40), end='\n')
-    #     pb = test_case.problem()
-    #
-    #     for planner in oneshot_planners():
-    #         planner = OneshotPlanner(name=planner)
-    #         if planner.supports(pb.kind):
-    #
-    #             print("  ", planner.name.ljust(80), end='')
-    #             start = time.time()
-    #             try:
-    #                 result = planner.solve(pb, timeout=1) #, output_stream=sys.stdout)
-    #                 end = time.time()
-    #                 status = str(result.status).replace("PlanGenerationResultStatus.", "").ljust(20)
-    #                 print("\t  ", status, "\t    ", end - start)
-    #                 if result.status == PlanGenerationResultStatus.INTERNAL_ERROR and result.log_messages is not None:
-    #                     print('\n'.join(map(str, result.log_messages)))
-    #
-    #             except Exception as e:
-    #                 print("\t CRASH !!!!", e)
-
-            # print(result.plan)
+    report()
 

--- a/report.py
+++ b/report.py
@@ -157,7 +157,6 @@ Usage
         prefix = planners.pop(prefix_opt)
     except ValueError:
         prefix = ""
-    print(prefix_opt)
 
     errors = report(*planners, problem_prefix=prefix)
     if len(errors) > 0:

--- a/report.py
+++ b/report.py
@@ -1,0 +1,180 @@
+import os
+import time
+
+from unified_planning.engines import PlanGenerationResultStatus
+
+
+
+
+# pip install https://github.com/plaans/aries/releases/download/latest/up_aries.tar.gz
+
+from unified_planning.shortcuts import *
+from unified_planning.model.htn import *
+import unified_planning as up
+from unified_planning.environment import get_environment
+get_environment().factory.add_engine('aries', 'up_aries', 'AriesDev')
+get_environment().credits_stream = None # silence credits
+
+def oneshot_planners():
+    # return ["aries"]
+    tags = [n for n in get_environment().factory.engines]
+    tags = [t for t in tags
+            if get_environment().factory.engine(t).is_oneshot_planner()]
+    return tags
+
+
+def up_tests():
+    from unified_planning.test.examples import get_example_problems
+
+    cases = []
+    for name, problem in get_example_problems().items():
+        pb = problem.problem.clone()
+        pb.name = f"up:{name}"
+        cases.append(TestCase(pb, solvable=True))
+    return cases
+
+
+def hddl_problems():
+    import os
+    import unified_planning.test
+    up_tests_path = os.path.dirname(unified_planning.test.__file__)
+    # directory where to find hddl instances
+    hddl_dir = os.path.join(up_tests_path, "hddl")
+
+    subfolders = [f.path for f in os.scandir(hddl_dir) if f.is_dir()]
+    problems = []
+    for id, domain in enumerate(subfolders[:]):
+        domain_filename = os.path.join(domain, "domain.hddl")
+        problem_filename = os.path.join(domain, "instance.1.pb.hddl")
+
+        if os.path.exists(domain_filename):
+            problem_name = "hddl:" + os.path.basename(domain)
+            problems.append(PDDLTestCase(
+                name=problem_name,
+                domain=domain_filename,
+                problem=problem_filename,
+                solvable=True
+            ))
+
+    return problems
+
+
+class TestCase:
+    def __init__(self, problem: up.model.Problem, solvable: bool):
+        self._problem = problem
+        self._solvable = solvable
+
+    def problem(self) -> up.model.Problem:
+        return self._problem
+
+    @property
+    def solvable(self):
+        return self._solvable
+
+    @property
+    def name(self) -> str:
+        return self.problem().name
+
+class PDDLTestCase(TestCase):
+    def __init__(self, name: str, domain: str, problem: str, solvable: bool):
+        self._name = name
+        self._domain_file = domain
+        self._problem_file = problem
+        super().__init__(problem=None, solvable=solvable)
+
+    def problem(self):
+        if self._problem is None:
+            # problem has not been parsed yet, parse and store
+            from unified_planning.io import PDDLReader
+            self._problem = PDDLReader().parse_problem(self._domain_file, self._problem_file)
+            self._problem.name = self._name
+        return self._problem
+
+    @property
+    def name(self):
+        return self._name
+
+
+def report(planner: Optional[str] = None,
+           planners: Optional[List[str]] = None,
+           problem_prefix: str = ""):
+
+    if planner is not None:
+        planners = [planner]
+    if planners is None:
+        planners = oneshot_planners()
+
+    problems = up_tests() + hddl_problems()
+    problems = [p for p in problems if p.name.startswith(problem_prefix)]
+
+    for test_case in problems:
+        # if test_case.name != "up:htn-go-temporal":
+        #     continue
+        print()
+        print(test_case.name.ljust(40), end='\n')
+        pb = test_case.problem()
+
+        for planner in planners:
+            planner = OneshotPlanner(name=planner)
+            if planner.supports(pb.kind):
+
+                print("  ", planner.name.ljust(80), end='')
+                start = time.time()
+                try:
+                    result = planner.solve(pb, timeout=1) #, output_stream=sys.stdout)
+                    end = time.time()
+                    status = str(result.status).replace("PlanGenerationResultStatus.", "").ljust(20)
+                    print("\t  ", status, "\t    ", end - start)
+                    if result.status == PlanGenerationResultStatus.INTERNAL_ERROR and result.log_messages is not None:
+                        print('\n'.join(map(str, result.log_messages)))
+
+                except Exception as e:
+                    print("\t CRASH !!!!", e)
+
+    
+
+TEST_REPO_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+if __name__ == "__main__":
+
+    # report(planner="fast-downward", problem_prefix="up:")
+    report(planners=["aries","fast-downward"], problem_prefix="hddl")
+
+    # # aries = up_aries.Aries()
+    # planners = oneshot_planners()
+    # print(planners)
+    #
+    # pbs = []
+    # pbs += up_tests()
+    # pbs += hddl_problems()
+    #
+    # planner = OneshotPlanner(name="aries")
+    #
+    #
+    # for test_case in pbs:
+    #     # if test_case.name != "up:htn-go-temporal":
+    #     #     continue
+    #     print()
+    #     print(test_case.name.ljust(40), end='\n')
+    #     pb = test_case.problem()
+    #
+    #     for planner in oneshot_planners():
+    #         planner = OneshotPlanner(name=planner)
+    #         if planner.supports(pb.kind):
+    #
+    #             print("  ", planner.name.ljust(80), end='')
+    #             start = time.time()
+    #             try:
+    #                 result = planner.solve(pb, timeout=1) #, output_stream=sys.stdout)
+    #                 end = time.time()
+    #                 status = str(result.status).replace("PlanGenerationResultStatus.", "").ljust(20)
+    #                 print("\t  ", status, "\t    ", end - start)
+    #                 if result.status == PlanGenerationResultStatus.INTERNAL_ERROR and result.log_messages is not None:
+    #                     print('\n'.join(map(str, result.log_messages)))
+    #
+    #             except Exception as e:
+    #                 print("\t CRASH !!!!", e)
+
+            # print(result.plan)
+


### PR DESCRIPTION
This PR aims to bring some initial tooling for assessing the adherence of planners to our integration guidelines.

For this we have a set of test cases. Each test case is a planning problem with some metadata to say e.g. whether it is solvable or not (pending: optimal quality).  Test cases a gathered regardless of their kind.

For each test cases, all planners that support it will be run. The objective is mostly to present the results in a way that can be quickly scanned visually. Results are accumulated and distinguish errors (return `unsolvable` on solvable instance) from warnings (e.g. timeout or no validator available for this problem).

Note: The compatibility tests are shamelessly taken from @roeger's awesome work on classical planning, with minor adaptations to accumulate the results rather than failing fast.

The script `report.py` allows running it. With command line parameters to restrict the planners/instances. To have a quick idea of what the output looks like, you can have a look at the failed `Report` CI job.
 
TODOs:
 - [ ] Add support for optimal planning
 - [ ] Gather other existing test cases in the repository
 - [ ] Unify `TestCase`  and `TestCaseProblem` 